### PR TITLE
Add npm test and report scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ Three CI/CD workflows run on every push and PR:
 
 ### Local Testing Commands
 ```bash
-# axe-core
-npm install --save-dev @axe-core/cli serve
-npx serve . -l 3000 &
-npx axe http://localhost:3000/accessibility-issues-demo.html
+# axe-core via npm scripts
+npm install
+npm run start &
+npm test
+npm run report
 
 # Pa11y
 npm install -g pa11y-ci

--- a/package.json
+++ b/package.json
@@ -3,5 +3,10 @@
     "@axe-core/cli": "^4.10.1",
     "@axe-core/puppeteer": "^4.10.1",
     "serve": "^14.2.4"
+  },
+  "scripts": {
+    "test": "node run-axe-tests.js",
+    "start": "serve . -l 3000",
+    "report": "node generate-report.js"
   }
 }


### PR DESCRIPTION
## Summary
- add npm scripts for running tests, local server, and report generation
- document new commands in README

## Testing
- `npm run start &` followed by `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68626adf7a3c8320a43da5fcf6c28f4a